### PR TITLE
Added missing task for installing brightbox ruby 2.2

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -567,6 +567,26 @@ module Moonshine
             sudo 'apt-get remove -q -y ^.*ruby.* || true'
             #TODO apt-pinning to ensure ruby is never installed via apt
           end
+          
+          task :brightbox22 do
+            remove_ruby_from_apt
+            run [
+              'sudo rm -f /usr/bin/ruby',
+              'sudo rm -f /usr/bin/gem',
+              'sudo rm -f /usr/bin/rake',
+              'sudo rm -f /usr/bin/rdoc',
+              'sudo rm -f /usr/bin/irb',
+              'sudo rm -f /usr/bin/erb',
+              'sudo rm -f /usr/bin/ri',
+              'sudo rm -f /usr/bin/testrb',
+              'sudo apt-get install python-software-properties software-properties-common -y',
+              'sudo apt-add-repository ppa:brightbox/ruby-ng -y',
+              'sudo apt-get update',
+              'sudo apt-get install ruby2.2 ruby2.2-dev -y'
+            ].join(' && ')
+            set :rubygems_version, fetch(:rubygems_version, '2.4.8')
+            set :bundler_version, fetch(:bundler_version, '1.9.10')
+          end
 
           task :brightbox21 do
             remove_ruby_from_apt


### PR DESCRIPTION
Using the latest master with #250 merged fails for me when specifying `brightbox22` as the ruby version.

Aso #250 did document `brightbox22` as [being supported](https://github.com/railsmachine/moonshine/blob/master/generators/moonshine/moonshine_generator.rb#L153) I've added the missing task for it here.

This is copied from the `brightbox21` task, I don't appreciate the purpose of each line in there so let me know if this should be modified further.
